### PR TITLE
add stable id to test cases

### DIFF
--- a/test/cases/indent-mode.json
+++ b/test/cases/indent-mode.json
@@ -12,7 +12,8 @@
         "(defn foo\n  [arg\n  ret"
       ],
       "out": "(defn foo\n  [arg]\n  ret)"
-    }
+    },
+    "id": 1000
   },
   {
     "text": "(defn foo\n  [arg\n   ret",
@@ -27,7 +28,8 @@
         "(defn foo\n  [arg\n   ret"
       ],
       "out": "(defn foo\n  [arg\n   ret])"
-    }
+    },
+    "id": 1005
   },
   {
     "text": "(defn foo\n[arg\n   ret",
@@ -42,7 +44,8 @@
         "(defn foo\n[arg\n   ret"
       ],
       "out": "(defn foo)\n[arg\n   ret]"
-    }
+    },
+    "id": 1010
   },
   {
     "text": "(defn foo\n[arg\nret",
@@ -57,7 +60,8 @@
         "(defn foo\n[arg\nret"
       ],
       "out": "(defn foo)\n[arg]\nret"
-    }
+    },
+    "id": 1015
   },
   {
     "text": "(defn foo\n  [arg\n  ret\n\n(defn foo\n  [arg\n  ret",
@@ -72,7 +76,8 @@
         "(defn foo\n  [arg\n  ret\n\n(defn foo\n  [arg\n  ret"
       ],
       "out": "(defn foo\n  [arg]\n  ret)\n\n(defn foo\n  [arg]\n  ret)"
-    }
+    },
+    "id": 1020
   },
   {
     "text": "bar)",
@@ -87,7 +92,8 @@
         "bar)"
       ],
       "out": "bar"
-    }
+    },
+    "id": 1025
   },
   {
     "text": "(def foo [a b]]",
@@ -102,7 +108,8 @@
         "(def foo [a b]]"
       ],
       "out": "(def foo [a b])"
-    }
+    },
+    "id": 1030
   },
   {
     "text": "(let [x {:foo 1 :bar 2]\n  x)",
@@ -117,7 +124,8 @@
         "(let [x {:foo 1 :bar 2]\n  x)"
       ],
       "out": "(let [x {:foo 1 :bar 2}]\n  x)"
-    }
+    },
+    "id": 1035
   },
   {
     "text": "(foo [a (b] c)",
@@ -142,7 +150,8 @@
         "(foo [a (|b] c)"
       ],
       "out": "(foo [a (|b] c)\n           ^ error: unmatched-close-paren"
-    }
+    },
+    "id": 1040
   },
   {
     "text": "(def foo \"as",
@@ -162,7 +171,8 @@
         "(def foo \"as"
       ],
       "out": "(def foo \"as\n         ^ error: unclosed-quote"
-    }
+    },
+    "id": 1045
   },
   {
     "text": "(defn foo [a \"])",
@@ -182,7 +192,8 @@
         "(defn foo [a \"])"
       ],
       "out": "(defn foo [a \"])\n             ^ error: unclosed-quote"
-    }
+    },
+    "id": 1050
   },
   {
     "text": "(defn foo\n  \"This is docstring.\n  Line 2 here.\"\n  ret",
@@ -197,7 +208,8 @@
         "(defn foo\n  \"This is docstring.\n  Line 2 here.\"\n  ret"
       ],
       "out": "(defn foo\n  \"This is docstring.\n  Line 2 here.\"\n  ret)"
-    }
+    },
+    "id": 1055
   },
   {
     "text": "(let [a \"Hello\nWorld\"\n      b 2\n  ret",
@@ -212,7 +224,8 @@
         "(let [a \"Hello\nWorld\"\n      b 2\n  ret"
       ],
       "out": "(let [a \"Hello\nWorld\"\n      b 2]\n  ret)"
-    }
+    },
+    "id": 1060
   },
   {
     "text": "(let [a \"])\"\n      b 2",
@@ -227,7 +240,8 @@
         "(let [a \"])\"\n      b 2"
       ],
       "out": "(let [a \"])\"\n      b 2])"
-    }
+    },
+    "id": 1065
   },
   {
     "text": "(def foo \"\\\"\"",
@@ -242,7 +256,8 @@
         "(def foo \"\\\"\""
       ],
       "out": "(def foo \"\\\"\")"
-    }
+    },
+    "id": 1070
   },
   {
     "text": "()\"\n\"",
@@ -257,7 +272,8 @@
         "()\"\n\""
       ],
       "out": "()\"\n\""
-    }
+    },
+    "id": 1075
   },
   {
     "text": "\"\"foo\"",
@@ -282,7 +298,8 @@
         "\"|\"foo\""
       ],
       "out": "\"|\"foo\"\n      ^ error: unclosed-quote"
-    }
+    },
+    "id": 1080
   },
   {
     "text": "(def foo\n  \"\n  \"(a b)\n      c\")",
@@ -307,7 +324,8 @@
         "(def foo\n  \"|\n  \"(a b)\n      c\")"
       ],
       "out": "(def foo\n  \"|\n  \"(a b)\n      c\")\n       ^ error: unclosed-quote"
-    }
+    },
+    "id": 1085
   },
   {
     "text": "(for [col columns]\n  \"\n  [:div.td {:style \"max-width: 500px;\"}])",
@@ -332,7 +350,8 @@
         "(for [col columns]\n  \"|\n  [:div.td {:style \"max-width: 500px;\"}])"
       ],
       "out": "(for [col columns]\n  \"|\n  [:div.td {:style \"max-width: 500px;\"}])\n                                     ^ error: quote-danger"
-    }
+    },
+    "id": 1090
   },
   {
     "text": "(def foo [a b]\n  ; \"my multiline\n  ; docstring.\"\nret)",
@@ -347,7 +366,8 @@
         "(def foo [a b]\n  ; \"my multiline\n  ; docstring.\"\nret)"
       ],
       "out": "(def foo [a b])\n  ; \"my multiline\n  ; docstring.\"\nret"
-    }
+    },
+    "id": 1095
   },
   {
     "text": "(def foo [a b]\n  ; \"\"\\\"\nret)",
@@ -362,7 +382,8 @@
         "(def foo [a b]\n  ; \"\"\\\"\nret)"
       ],
       "out": "(def foo [a b])\n  ; \"\"\\\"\nret"
-    }
+    },
+    "id": 1100
   },
   {
     "text": "(defn foo [a b\n  \\[\n  ret",
@@ -377,7 +398,8 @@
         "(defn foo [a b\n  \\[\n  ret"
       ],
       "out": "(defn foo [a b]\n  \\[\n  ret)"
-    }
+    },
+    "id": 1105
   },
   {
     "text": "(defn foo [a b]\n  ret\\)",
@@ -392,7 +414,8 @@
         "(defn foo [a b]\n  ret\\)"
       ],
       "out": "(defn foo [a b]\n  ret\\))"
-    }
+    },
+    "id": 1110
   },
   {
     "text": "{:tag-open \\[ :tag-close \\]}\n{:tag-open \\[ :tag-close \\]}",
@@ -407,7 +430,8 @@
         "{:tag-open \\[ :tag-close \\]}\n{:tag-open \\[ :tag-close \\]}"
       ],
       "out": "{:tag-open \\[ :tag-close \\]}\n{:tag-open \\[ :tag-close \\]}"
-    }
+    },
+    "id": 1115
   },
   {
     "text": "(def foo \\;",
@@ -422,7 +446,8 @@
         "(def foo \\;"
       ],
       "out": "(def foo \\;)"
-    }
+    },
+    "id": 1120
   },
   {
     "text": "(def foo \\,\n(def bar \\ ; <-- space",
@@ -437,7 +462,8 @@
         "(def foo \\,\n(def bar \\ ; <-- space"
       ],
       "out": "(def foo \\,)\n(def bar \\ ); <-- space"
-    }
+    },
+    "id": 1125
   },
   {
     "text": "(foo [a b\\\n  c)",
@@ -457,7 +483,8 @@
         "(foo [a b\\\n  c)"
       ],
       "out": "(foo [a b\\\n         ^ error: eol-backslash\n  c)"
-    }
+    },
+    "id": 1130
   },
   {
     "text": "(def foo ;)",
@@ -472,7 +499,8 @@
         "(def foo ;)"
       ],
       "out": "(def foo) ;)"
-    }
+    },
+    "id": 1135
   },
   {
     "text": "(let [a 1\n      b 2\n      c {:foo 1\n         ;; :bar 2}]\n  ret)",
@@ -487,7 +515,8 @@
         "(let [a 1\n      b 2\n      c {:foo 1\n         ;; :bar 2}]\n  ret)"
       ],
       "out": "(let [a 1\n      b 2\n      c {:foo 1}]\n         ;; :bar 2}]\n  ret)"
-    }
+    },
+    "id": 1140
   },
   {
     "text": "(let [a 1 ;; a comment\n  ret)",
@@ -502,7 +531,8 @@
         "(let [a 1 ;; a comment\n  ret)"
       ],
       "out": "(let [a 1] ;; a comment\n  ret)"
-    }
+    },
+    "id": 1145
   },
   {
     "text": "; hello \\n world",
@@ -517,7 +547,8 @@
         "; hello \\n world"
       ],
       "out": "; hello \\n world"
-    }
+    },
+    "id": 1150
   },
   {
     "text": "(def b )",
@@ -537,7 +568,8 @@
         "(def b |)"
       ],
       "out": "(def b |)"
-    }
+    },
+    "id": 1155
   },
   {
     "text": "(def b )",
@@ -552,7 +584,8 @@
         "(def b )"
       ],
       "out": "(def b)"
-    }
+    },
+    "id": 1160
   },
   {
     "text": "(def b [[c d] ])",
@@ -572,7 +605,8 @@
         "(def b [[c d] |])"
       ],
       "out": "(def b [[c d] |])"
-    }
+    },
+    "id": 1165
   },
   {
     "text": "(def b [[c d] ])",
@@ -587,7 +621,8 @@
         "(def b [[c d] ])"
       ],
       "out": "(def b [[c d]])"
-    }
+    },
+    "id": 1170
   },
   {
     "text": "(let [a 1])\n  ret)",
@@ -602,7 +637,8 @@
         "(let [a 1])\n  ret)"
       ],
       "out": "(let [a 1]\n  ret)"
-    }
+    },
+    "id": 1175
   },
   {
     "text": "(let [a 1])\n  ret)",
@@ -622,7 +658,8 @@
         "(let [a 1])|\n  ret)"
       ],
       "out": "(let [a 1])|\n  ret"
-    }
+    },
+    "id": 1180
   },
   {
     "text": "(let [a 1]) 2\n  ret",
@@ -637,7 +674,8 @@
         "(let [a 1]) 2\n  ret"
       ],
       "out": "(let [a 1]) 2\n  ret"
-    }
+    },
+    "id": 1185
   },
   {
     "text": "(let [a 1])\n  ret)",
@@ -657,7 +695,8 @@
         "(let [a 1]|)\n  ret)"
       ],
       "out": "(let [a 1]|\n  ret)"
-    }
+    },
+    "id": 1190
   },
   {
     "text": "(let [a 1]) ;\n  ret",
@@ -677,7 +716,8 @@
         "(let [a 1]) ;|\n  ret"
       ],
       "out": "(let [a 1] ;|\n  ret)"
-    }
+    },
+    "id": 1195
   },
   {
     "text": "(foo)}}}}",
@@ -697,7 +737,8 @@
         "(foo)}}}}|"
       ],
       "out": "(foo)|"
-    }
+    },
+    "id": 1200
   },
   {
     "text": "(foo}}}})",
@@ -717,7 +758,8 @@
         "(foo}}}}|)"
       ],
       "out": "(foo|)"
-    }
+    },
+    "id": 1205
   },
   {
     "text": "(foo\n  ) bar",
@@ -737,7 +779,8 @@
         "(foo\n  ) bar"
       ],
       "out": "(foo\n  ) bar\n  ^ error: leading-close-paren"
-    }
+    },
+    "id": 1210
   },
   {
     "text": "(foo\n  ); comment",
@@ -752,7 +795,8 @@
         "(foo\n  ); comment"
       ],
       "out": "(foo)\n  ; comment"
-    }
+    },
+    "id": 1215
   },
   {
     "text": "[(foo\n  )] bar",
@@ -772,7 +816,8 @@
         "[(foo\n  )] bar"
       ],
       "out": "[(foo\n  )] bar\n  ^ error: leading-close-paren"
-    }
+    },
+    "id": 1220
   },
   {
     "text": "(foo [bar (...] baz)",
@@ -797,7 +842,8 @@
         "(foo [bar (|...] baz)"
       ],
       "out": "(foo [bar (|...] baz)\n               ^ error: unmatched-close-paren"
-    }
+    },
+    "id": 1225
   },
   {
     "text": "(foo [bar (] baz)])",
@@ -822,7 +868,8 @@
         "(foo [bar (]| baz)])"
       ],
       "out": "(foo [bar (]| baz)])\n           ^ error: unmatched-close-paren"
-    }
+    },
+    "id": 1230
   },
   {
     "text": "[... (foo [bar ] baz]  ...)]",
@@ -847,7 +894,8 @@
         "[... (foo [bar ]| baz]  ...)]"
       ],
       "out": "[... (foo [bar ]| baz]  ...)]\n                     ^ error: unmatched-close-paren"
-    }
+    },
+    "id": 1235
   },
   {
     "text": "(let [{:keys foo bar]} my-map])",
@@ -872,7 +920,8 @@
         "(let [{:keys |foo bar]} my-map])"
       ],
       "out": "(let [{:keys |foo bar]} my-map])\n                     ^ error: unmatched-close-paren"
-    }
+    },
+    "id": 1240
   },
   {
     "text": "(a (b (c)) d) e)",
@@ -892,7 +941,8 @@
         "(a (b (c))| d) e)"
       ],
       "out": "(a (b (c))| d) e"
-    }
+    },
+    "id": 1245
   },
   {
     "text": "(a (b (c() d) e)",
@@ -912,7 +962,8 @@
         "(a (b (c(|) d) e)"
       ],
       "out": "(a (b (c(|) d) e))"
-    }
+    },
+    "id": 1250
   },
   {
     "text": "(f [x (a (b c() d) y] g)",
@@ -937,7 +988,8 @@
         "(f [x (a (b c(|) d) y] g)"
       ],
       "out": "(f [x (a (b c(|) d) y] g)\n                     ^ error: unmatched-close-paren"
-    }
+    },
+    "id": 1255
   },
   {
     "text": "(foo\n  bar) baz) qux",
@@ -962,7 +1014,8 @@
         "(foo\n  bar)| baz) qux"
       ],
       "out": "(foo\n  bar)| baz) qux\n           ^ error: unmatched-close-paren"
-    }
+    },
+    "id": 1260
   },
   {
     "text": "(foo\n  [bar\n   bar) baz\n   bar])",
@@ -987,7 +1040,8 @@
         "(foo\n  [bar\n   bar)| baz\n   bar])"
       ],
       "out": "(foo\n  [bar\n   bar)| baz\n      ^ error: unmatched-close-paren\n   bar])"
-    }
+    },
+    "id": 1265
   },
   {
     "text": "(foo\n  [bar]\nbar) baz",
@@ -1012,7 +1066,8 @@
         "(foo\n  [bar]\n|bar) baz"
       ],
       "out": "(foo\n  [bar]\n|bar) baz\n    ^ error: unmatched-close-paren"
-    }
+    },
+    "id": 1270
   },
   {
     "text": "(foo\n [bar]\n  bar) baz",
@@ -1037,7 +1092,8 @@
         "(foo\n [bar]\n  |bar) baz"
       ],
       "out": "(foo\n [bar]\n  |bar) baz\n      ^ error: unmatched-close-paren"
-    }
+    },
+    "id": 1275
   },
   {
     "text": "(foo\n [bar\n bar]) baz",
@@ -1057,7 +1113,8 @@
         "(foo\n [bar\n bar]) baz"
       ],
       "out": "(foo\n [bar\n bar]) baz\n    ^ error: unmatched-close-paren"
-    }
+    },
+    "id": 1280
   },
   {
     "text": "(foo bar ;)",
@@ -1077,7 +1134,8 @@
         "(foo bar ;|)"
       ],
       "out": "(foo bar) ;|)"
-    }
+    },
+    "id": 1285
   },
   {
     "text": "(let [x 1\n      y 2;])",
@@ -1097,7 +1155,8 @@
         "(let [x 1\n      y 2;|])"
       ],
       "out": "(let [x 1\n      y 2]);|])"
-    }
+    },
+    "id": 1290
   },
   {
     "text": "(",
@@ -1117,7 +1176,8 @@
         "(|"
       ],
       "out": "(|)"
-    }
+    },
+    "id": 1295
   },
   {
     "text": "(def x [1 2 3])\n(def y 2)\n",
@@ -1145,7 +1205,8 @@
         "(def x [1 2 3])\n(def y 2)\n|"
       ],
       "out": "(def x [1 2 3])\n(def y 2)\n^    > tabStops\n|"
-    }
+    },
+    "id": 1300
   },
   {
     "text": "(foo bar\n  (baz boo))\n",
@@ -1178,7 +1239,8 @@
         "(foo bar\n  (baz boo))\n|"
       ],
       "out": "(foo bar\n  (baz boo))\n^ ^    > tabStops\n|"
-    }
+    },
+    "id": 1305
   },
   {
     "text": "(let [a {:foo 1}\n      \n      bar [1 2 3]]\n  bar)",
@@ -1216,7 +1278,8 @@
         "(let [a {:foo 1}\n      |\n      bar [1 2 3]]\n  bar)"
       ],
       "out": "(let [a {:foo 1}\n^    ^  ^     > tabStops\n      |\n      bar [1 2 3]]\n  bar)"
-    }
+    },
+    "id": 1310
   },
   {
     "text": "(let [a {:foo 1}\n      bar (func 1 2 3)]\n  \n  bar)",
@@ -1254,7 +1317,8 @@
         "(let [a {:foo 1}\n      bar (func 1 2 3)]\n  |\n  bar)"
       ],
       "out": "(let [a {:foo 1}\n      bar (func 1 2 3)]\n^    ^    ^     > tabStops\n  |\n  bar)"
-    }
+    },
+    "id": 1315
   },
   {
     "text": "(defn foo\n  \"hello, this is a docstring\"\n  [a b]\n  (let [sum (+ a b)\n        prod (* a b)]\n     {:sum sum\n      :prod prod}))",
@@ -1291,6 +1355,7 @@
         "(defn foo\n  \"hello, this is a docstring\"\n  [a b]\n  (let [sum (+ a b)\n        prod (* a b)]\n     {:sum sum\n      :prod prod}))"
       ],
       "out": "(defn foo\n  \"hello, this is a docstring\"\n  [a b]\n      ^ parenTrail\n  (let [sum (+ a b)\n                  ^ parenTrail\n        prod (* a b)]\n                   ^^ parenTrail\n     {:sum sum\n      :prod prod}))\n                ^^^ parenTrail"
-    }
+    },
+    "id": 1320
   }
 ]

--- a/test/cases/indent-mode.md
+++ b/test/cases/indent-mode.md
@@ -4,7 +4,7 @@
 
 Most basic behavior can be described by leaving out close-parens.
 
-```in
+```in:1000
 (defn foo
   [arg
   ret
@@ -18,7 +18,7 @@ Most basic behavior can be described by leaving out close-parens.
 
 indenting line 3:
 
-```in
+```in:1005
 (defn foo
   [arg
    ret
@@ -32,7 +32,7 @@ indenting line 3:
 
 dedenting line 2:
 
-```in
+```in:1010
 (defn foo
 [arg
    ret
@@ -46,7 +46,7 @@ dedenting line 2:
 
 dedenting line 2 and 3:
 
-```in
+```in:1015
 (defn foo
 [arg
 ret
@@ -60,7 +60,7 @@ ret
 
 multiple functions:
 
-```in
+```in:1020
 (defn foo
   [arg
   ret
@@ -84,7 +84,7 @@ multiple functions:
 
 close-paren at end-of-line with no open-paren:
 
-```in
+```in:1025
 bar)
 ```
 
@@ -94,7 +94,7 @@ bar
 
 close-paren at end-of-line is wrong type:
 
-```in
+```in:1030
 (def foo [a b]]
 ```
 
@@ -104,7 +104,7 @@ close-paren at end-of-line is wrong type:
 
 insert missing close-paren inside another when at end-of-line:
 
-```in
+```in:1035
 (let [x {:foo 1 :bar 2]
   x)
 ```
@@ -116,7 +116,7 @@ insert missing close-paren inside another when at end-of-line:
 
 unmatched close-parens _inside_ a line are removed:
 
-```in
+```in:1040
 (foo [a (|b] c)
 ```
 
@@ -129,7 +129,7 @@ unmatched close-parens _inside_ a line are removed:
 
 No close-parens are inserted when a string is unclosed.
 
-```in
+```in:1045
 (def foo "as
 ```
 
@@ -140,7 +140,7 @@ No close-parens are inserted when a string is unclosed.
 
 even if close-parens are quoted out, do not do anything.
 
-```in
+```in:1050
 (defn foo [a "])
 ```
 
@@ -151,7 +151,7 @@ even if close-parens are quoted out, do not do anything.
 
 Multiline strings are supported:
 
-```in
+```in:1055
 (defn foo
   "This is docstring.
   Line 2 here."
@@ -167,7 +167,7 @@ Multiline strings are supported:
 
 Indentation inside multiline strings does not trigger Parinfer's indentation rules.
 
-```in
+```in:1060
 (let [a "Hello
 World"
       b 2
@@ -183,7 +183,7 @@ World"
 
 Close-parens are ignored when inside strings.
 
-```in
+```in:1065
 (let [a "])"
       b 2
 ```
@@ -195,7 +195,7 @@ Close-parens are ignored when inside strings.
 
 Escaped quotes are handled correctly.
 
-```in
+```in:1070
 (def foo "\""
 ```
 
@@ -206,7 +206,7 @@ Escaped quotes are handled correctly.
 A line ending inside a string will not have a definable Paren Trail.  This
 minimal test case will fail if the close-paren is treated as a Paren Trail.
 
-```in
+```in:1075
 ()"
 "
 ```
@@ -225,7 +225,7 @@ the left of the cursor.
 Typing a quote before another string does not corrupt it (i.e. turn it inside
 out, causing Parinfer to treat its contents as code).
 
-```in
+```in:1080
 "|"foo"
 ```
 
@@ -236,7 +236,7 @@ out, causing Parinfer to treat its contents as code).
 
 Another case:
 
-```in
+```in:1085
 (def foo
   "|
   "(a b)
@@ -260,7 +260,7 @@ Notice that the following code is correctly balanced, quite accidentally, but
 Parinfer does not process it because the last line contains a comment with an
 odd number of quotes (one):
 
-```in
+```in:1090
 (for [col columns]
   "|
   [:div.td {:style "max-width: 500px;"}])
@@ -277,7 +277,7 @@ But a comment can contain an odd number of quotes if it is in a contiguous group
 which contain an even number of them.  This allows commenting out a multiline string without
 any problems:
 
-```in
+```in:1095
 (def foo [a b]
   ; "my multiline
   ; docstring."
@@ -293,7 +293,7 @@ ret
 
 Escaped strings are not counted when determining odd number of quotes in a comment.
 
-```in
+```in:1100
 (def foo [a b]
   ; ""\"
 ret)
@@ -309,7 +309,7 @@ ret
 
 Correctly handle escaped parens as literal characters.
 
-```in
+```in:1105
 (defn foo [a b
   \[
   ret
@@ -321,7 +321,7 @@ Correctly handle escaped parens as literal characters.
   ret)
 ```
 
-```in
+```in:1110
 (defn foo [a b]
   ret\)
 ```
@@ -331,7 +331,7 @@ Correctly handle escaped parens as literal characters.
   ret\))
 ```
 
-```in
+```in:1115
 {:tag-open \[ :tag-close \]}
 {:tag-open \[ :tag-close \]}
 ```
@@ -344,7 +344,7 @@ Correctly handle escaped parens as literal characters.
 Correctly handle escaped semicolons as characters instead of comments.
 Otherwise, the inferred close-parens would be inserted before them.
 
-```in
+```in:1120
 (def foo \;
 ```
 
@@ -354,7 +354,7 @@ Otherwise, the inferred close-parens would be inserted before them.
 
 Inferred close-parens are inserted after escaped whitespace.
 
-```in
+```in:1125
 (def foo \,
 (def bar \ ; <-- space
 ```
@@ -366,7 +366,7 @@ Inferred close-parens are inserted after escaped whitespace.
 
 Hanging backslash at end of line is invalid and causes processing to be abandoned.
 
-```in
+```in:1130
 (foo [a b\
   c)
 ```
@@ -382,7 +382,7 @@ Hanging backslash at end of line is invalid and causes processing to be abandone
 When commenting-out an inferred close-paren, a new one should be inserted
 before it.
 
-```in
+```in:1135
 (def foo ;)
 ```
 
@@ -393,7 +393,7 @@ before it.
 Commenting-out a line containing inferred close-parens should cause new ones to
 be inserted at the previous non-empty line.
 
-```in
+```in:1140
 (let [a 1
       b 2
       c {:foo 1
@@ -411,7 +411,7 @@ be inserted at the previous non-empty line.
 
 Inferred close-parens are inserted before comments.
 
-```in
+```in:1145
 (let [a 1 ;; a comment
   ret)
 ```
@@ -423,7 +423,7 @@ Inferred close-parens are inserted before comments.
 
 escape character in comment untouched:
 
-```in
+```in:1150
 ; hello \n world
 ```
 
@@ -440,7 +440,7 @@ __NOTE__: the pipe `|` represents the cursor, but the character is removed from 
 Inferred close-parens can only be inserted to the right of the cursor (if it is present).
 This allows us to insert a space before typing a new token.
 
-```in
+```in:1155
 (def b |)
 ```
 
@@ -450,7 +450,7 @@ This allows us to insert a space before typing a new token.
 
 Once the cursor leaves the line, the space is removed.
 
-```in
+```in:1160
 (def b )
 ```
 
@@ -460,7 +460,7 @@ Once the cursor leaves the line, the space is removed.
 
 Another example with more close-parens:
 
-```in
+```in:1165
 (def b [[c d] |])
 ```
 
@@ -470,7 +470,7 @@ Another example with more close-parens:
 
 Once the cursor leaves the line, the space is removed.
 
-```in
+```in:1170
 (def b [[c d] ])
 ```
 
@@ -486,7 +486,7 @@ after such a close-paren.
 
 For example, without the cursor on the first line, this is expected:
 
-```in
+```in:1175
 (let [a 1])
   ret)
 ```
@@ -498,7 +498,7 @@ For example, without the cursor on the first line, this is expected:
 
 With the cursor at the end of the first line, the indented line below does not affect it.
 
-```in
+```in:1180
 (let [a 1])|
   ret)
 ```
@@ -511,7 +511,7 @@ With the cursor at the end of the first line, the indented line below does not a
 If this was not allowed, we would not be able to reach this valid state from
 the previous state:
 
-```in
+```in:1185
 (let [a 1]) 2
   ret
 ```
@@ -524,7 +524,7 @@ the previous state:
 But if the cursor is before such a close-paren, we are not in a position to
 insert a token after it, thus indentation can affect it again:
 
-```in
+```in:1190
 (let [a 1]|)
   ret)
 ```
@@ -536,7 +536,7 @@ insert a token after it, thus indentation can affect it again:
 
 If the cursor is in a comment after such a close-paren, we can safely move it:
 
-```in
+```in:1195
 (let [a 1]) ;|
   ret
 ```
@@ -548,7 +548,7 @@ If the cursor is in a comment after such a close-paren, we can safely move it:
 
 The cursor should not keep unmatched close-parens in the trail:
 
-```in
+```in:1200
 (foo)}}}}|
 ```
 
@@ -556,7 +556,7 @@ The cursor should not keep unmatched close-parens in the trail:
 (foo)|
 ```
 
-```in
+```in:1205
 (foo}}}}|)
 ```
 
@@ -572,7 +572,7 @@ these in tests).
 
 If `forceBalance` is not on, we suspend Indent Mode.
 
-```in
+```in:1210
 (foo
   ) bar
 ```
@@ -585,7 +585,7 @@ If `forceBalance` is not on, we suspend Indent Mode.
 
 It is allowed if the leading parens are also in paren trail:
 
-```in
+```in:1215
 (foo
   ); comment
 ```
@@ -597,7 +597,7 @@ It is allowed if the leading parens are also in paren trail:
 
 If there's more than one, point to the first one.
 
-```in
+```in:1220
 [(foo
   )] bar
 ```
@@ -619,7 +619,7 @@ ever approached again.
 
 Inserting a `(` inside a nested vector:
 
-```in
+```in:1225
 (foo [bar (|...] baz)
 ```
 
@@ -630,7 +630,7 @@ Inserting a `(` inside a nested vector:
 
 Inserting a `]` inside a nested list:
 
-```in
+```in:1230
 (foo [bar (]| baz)])
 ```
 
@@ -642,7 +642,7 @@ Inserting a `]` inside a nested list:
 Inserting a `]` ahead of another inside a list (maybe to "barf" the end of the
 vector).
 
-```in
+```in:1235
 [... (foo [bar ]| baz]  ...)]
 ```
 
@@ -653,7 +653,7 @@ vector).
 
 Suppose you just backspaced a `[` below:
 
-```in
+```in:1240
 (let [{:keys |foo bar]} my-map])
 ```
 
@@ -664,7 +664,7 @@ Suppose you just backspaced a `[` below:
 
 Inserting a matched `)` inside nested expressions sometimes works out:
 
-```in
+```in:1245
 (a (b (c))| d) e)
 ```
 
@@ -674,7 +674,7 @@ Inserting a matched `)` inside nested expressions sometimes works out:
 
 Inserting a matched `(` inside nested expressions sometimes works out too:
 
-```in
+```in:1250
 (a (b (c(|) d) e)
 ```
 
@@ -684,7 +684,7 @@ Inserting a matched `(` inside nested expressions sometimes works out too:
 
 But all it takes is one different kind of a paren to keep it from working:
 
-```in
+```in:1255
 (f [x (a (b c(|) d) y] g)
 ```
 
@@ -696,7 +696,7 @@ But all it takes is one different kind of a paren to keep it from working:
 Unmatched close-parens on indented lines present similar issues.
 For example, inserting a `)` below:
 
-```in
+```in:1260
 (foo
   bar)| baz) qux
 ```
@@ -707,7 +707,7 @@ For example, inserting a `)` below:
            ^ error: unmatched-close-paren
 ```
 
-```in
+```in:1265
 (foo
   [bar
    bar)| baz
@@ -724,7 +724,7 @@ For example, inserting a `)` below:
 
 Or when dedenting a line makes an inner close-paren unmatched:
 
-```in
+```in:1270
 (foo
   [bar]
 |bar) baz
@@ -740,7 +740,7 @@ Or when dedenting a line makes an inner close-paren unmatched:
 In the same example, a different similar problem emerges when indenting a line
 makes the same inner close-paren unmatched:
 
-```in
+```in:1275
 (foo
  [bar]
   |bar) baz
@@ -755,7 +755,7 @@ makes the same inner close-paren unmatched:
 
 The same problem demonstrated for another dedenting example:
 
-```in
+```in:1280
 (foo
  [bar
  bar]) baz
@@ -772,7 +772,7 @@ The same problem demonstrated for another dedenting example:
 
 Commenting an inferred close-paren
 
-```in
+```in:1285
 (foo bar ;|)
 ```
 
@@ -782,7 +782,7 @@ Commenting an inferred close-paren
 
 Commenting multiple inferred close-parens
 
-```in
+```in:1290
 (let [x 1
       y 2;|])
 ```
@@ -794,7 +794,7 @@ Commenting multiple inferred close-parens
 
 When typing an open-paren, a close-paren should come after the cursor:
 
-```in
+```in:1295
 (|
 ```
 
@@ -808,7 +808,7 @@ We can return the positions of the open-parens whose structure would be
 affected by the indentation of the current cursor line.  This allows editors to
 use them to create tab stops for smart indentation snapping.
 
-```in
+```in:1300
 (def x [1 2 3])
 (def y 2)
 |
@@ -824,7 +824,7 @@ use them to create tab stops for smart indentation snapping.
 The `>` means the position of the first arg after an open-paren, because some styles
 use it for alignment.
 
-```in
+```in:1305
 (foo bar
   (baz boo))
 |
@@ -837,7 +837,7 @@ use it for alignment.
 |
 ```
 
-```in
+```in:1310
 (let [a {:foo 1}
       |
       bar [1 2 3]]
@@ -853,7 +853,7 @@ use it for alignment.
 ```
 
 
-```in
+```in:1315
 (let [a {:foo 1}
       bar (func 1 2 3)]
   |
@@ -872,7 +872,7 @@ use it for alignment.
 
 We return non-empty Paren Trails so plugins can dim them with markers:
 
-```in
+```in:1320
 (defn foo
   "hello, this is a docstring"
   [a b]

--- a/test/cases/paren-mode.json
+++ b/test/cases/paren-mode.json
@@ -12,7 +12,8 @@
         "(let [foo 1]\nfoo)"
       ],
       "out": "(let [foo 1]\n foo)"
-    }
+    },
+    "id": 2000
   },
   {
     "text": "(let [foo 1]\n      foo)",
@@ -27,7 +28,8 @@
         "(let [foo 1]\n      foo)"
       ],
       "out": "(let [foo 1]\n     foo)"
-    }
+    },
+    "id": 2005
   },
   {
     "text": "(let [foo {:a 1}]\n           foo)",
@@ -42,7 +44,8 @@
         "(let [foo {:a 1}]\n           foo)"
       ],
       "out": "(let [foo {:a 1}]\n     foo)"
-    }
+    },
+    "id": 2010
   },
   {
     "text": "(let [foo 1]\n      foo)\n\n(let [foo 1]\nfoo)",
@@ -57,7 +60,8 @@
         "(let [foo 1]\n      foo)\n\n(let [foo 1]\nfoo)"
       ],
       "out": "(let [foo 1]\n     foo)\n\n(let [foo 1]\n foo)"
-    }
+    },
+    "id": 2015
   },
   {
     "text": "(let [foo [1 2 3]]\n      (-> foo\n          (map inc)))",
@@ -72,7 +76,8 @@
         "(let [foo [1 2 3]]\n      (-> foo\n          (map inc)))"
       ],
       "out": "(let [foo [1 2 3]]\n     (-> foo\n         (map inc)))"
-    }
+    },
+    "id": 2020
   },
   {
     "text": "(let [foo 1\n      ]; <-- spaces\n  foo)",
@@ -87,7 +92,8 @@
         "(let [foo 1\n      ]; <-- spaces\n  foo)"
       ],
       "out": "(let [foo 1]\n      ; <-- spaces\n  foo)"
-    }
+    },
+    "id": 2025
   },
   {
     "text": "(let [foo 1\n      bar 2\n\n     ] (+ foo bar\n  ); <-- spaces\n)",
@@ -102,7 +108,8 @@
         "(let [foo 1\n      bar 2\n\n     ] (+ foo bar\n  ); <-- spaces\n)"
       ],
       "out": "(let [foo 1\n      bar 2]\n\n     (+ foo bar))\n  ; <-- spaces\n"
-    }
+    },
+    "id": 2030
   },
   {
     "text": "(def x [1 2 3 4\n         5 6 7 8])",
@@ -117,7 +124,8 @@
         "(def x [1 2 3 4\n         5 6 7 8])"
       ],
       "out": "(def x [1 2 3 4\n         5 6 7 8])"
-    }
+    },
+    "id": 2035
   },
   {
     "text": "  (assoc x\n:foo 1\n     :bar 2)",
@@ -132,7 +140,8 @@
         "  (assoc x\n:foo 1\n     :bar 2)"
       ],
       "out": "  (assoc x\n   :foo 1\n     :bar 2)"
-    }
+    },
+    "id": 2040
   },
   {
     "text": "(foo",
@@ -152,7 +161,8 @@
         "(foo"
       ],
       "out": "(foo\n^ error: unclosed-paren"
-    }
+    },
+    "id": 2045
   },
   {
     "text": "(defn foo\n[arg arg2\nbar",
@@ -172,7 +182,8 @@
         "(defn foo\n[arg arg2\nbar"
       ],
       "out": "(defn foo\n[arg arg2\n^ error: unclosed-paren\nbar"
-    }
+    },
+    "id": 2050
   },
   {
     "text": "(foo})",
@@ -192,7 +203,8 @@
         "(foo})"
       ],
       "out": "(foo})\n    ^ error: unmatched-close-paren"
-    }
+    },
+    "id": 2055
   },
   {
     "text": "(foo\n  })",
@@ -212,7 +224,8 @@
         "(foo\n  })"
       ],
       "out": "(foo\n  })\n  ^ error: unmatched-close-paren"
-    }
+    },
+    "id": 2060
   },
   {
     "text": "(defn foo\n  [arg\n  bar)",
@@ -232,7 +245,8 @@
         "(defn foo\n  [arg\n  bar)"
       ],
       "out": "(defn foo\n  [arg\n  bar)\n     ^ error: unmatched-close-paren"
-    }
+    },
+    "id": 2065
   },
   {
     "text": "; hello \\n world",
@@ -247,7 +261,8 @@
         "; hello \\n world"
       ],
       "out": "; hello \\n world"
-    }
+    },
+    "id": 2070
   },
   {
     "text": "(def foo \\,)\n(def bar \\ )",
@@ -262,7 +277,8 @@
         "(def foo \\,)\n(def bar \\ )"
       ],
       "out": "(def foo \\,)\n(def bar \\ )"
-    }
+    },
+    "id": 2075
   },
   {
     "text": "(foo [a b]\\\nc)",
@@ -282,7 +298,8 @@
         "(foo [a b]\\\nc)"
       ],
       "out": "(foo [a b]\\\n          ^ error: eol-backslash\nc)"
-    }
+    },
+    "id": 2080
   },
   {
     "text": "(def foo\n  \"hello\n  bar)",
@@ -302,7 +319,8 @@
         "(def foo\n  \"hello\n  bar)"
       ],
       "out": "(def foo\n  \"hello\n  ^ error: unclosed-quote\n  bar)"
-    }
+    },
+    "id": 2085
   },
   {
     "text": "(def foo [a b]\n  ; \"my string\nret)",
@@ -322,7 +340,8 @@
         "(def foo [a b]\n  ; \"my string\nret)"
       ],
       "out": "(def foo [a b]\n  ; \"my string\n    ^ error: quote-danger\nret)"
-    }
+    },
+    "id": 2090
   },
   {
     "text": "(def foo [a b]\n  ; \"my multiline\n  ; docstring.\"\nret)",
@@ -337,7 +356,8 @@
         "(def foo [a b]\n  ; \"my multiline\n  ; docstring.\"\nret)"
       ],
       "out": "(def foo [a b]\n  ; \"my multiline\n  ; docstring.\"\n ret)"
-    }
+    },
+    "id": 2095
   },
   {
     "text": "( )\"\n\"",
@@ -352,7 +372,8 @@
         "( )\"\n\""
       ],
       "out": "( )\"\n\""
-    }
+    },
+    "id": 2100
   },
   {
     "text": "(foo )",
@@ -372,7 +393,8 @@
         "(foo |)"
       ],
       "out": "(foo |)"
-    }
+    },
+    "id": 2105
   },
   {
     "text": "(foo [1 2 3 ] )",
@@ -392,7 +414,8 @@
         "(foo [1 2 3 |] )"
       ],
       "out": "(foo [1 2 3 |] )"
-    }
+    },
+    "id": 2110
   },
   {
     "text": "(foo )",
@@ -407,7 +430,8 @@
         "(foo )"
       ],
       "out": "(foo)"
-    }
+    },
+    "id": 2115
   },
   {
     "text": "(foo [1 2 3 ] )",
@@ -422,7 +446,8 @@
         "(foo [1 2 3 ] )"
       ],
       "out": "(foo [1 2 3])"
-    }
+    },
+    "id": 2120
   },
   {
     "text": "(foo [a b\n])",
@@ -442,7 +467,8 @@
         "(foo [a b\n|])"
       ],
       "out": "(foo [a b\n      |])"
-    }
+    },
+    "id": 2125
   },
   {
     "text": "(foo [1 2 3\n 4 5 6\n 7 8 9])",
@@ -462,7 +488,8 @@
         "(foo [1 2 3\n 4 5 6\n 7 8 9])|"
       ],
       "out": "(foo [1 2 3\n      4 5 6\n      7 8 9])|"
-    }
+    },
+    "id": 2130
   },
   {
     "text": "(let [foo 1\n           ; comment 1\n           bar 2\n           baz 3])\n           ; comment 2",
@@ -486,7 +513,8 @@
         "(let     [foo 1\n     ----\n           ; comment 1\n           bar 2\n           baz 3])\n           ; comment 2"
       ],
       "out": "(let [foo 1\n       ; comment 1\n       bar 2\n       baz 3])\n       ; comment 2"
-    }
+    },
+    "id": 2135
   },
   {
     "text": "(def foo\n      ; comment 1\n      bar)\n      ; comment 2",
@@ -510,7 +538,8 @@
         "   (def foo\n---\n      ; comment 1\n      bar)\n      ; comment 2"
       ],
       "out": "(def foo\n   ; comment 1\n   bar)\n   ; comment 2"
-    }
+    },
+    "id": 2140
   },
   {
     "text": "(def foo (bar\n       4 5 6\n       ; comment 1\n       7 8 9))\n       ; comment 2",
@@ -534,7 +563,8 @@
         "(def foo (bar\n    ++++\n       4 5 6\n       ; comment 1\n       7 8 9))\n       ; comment 2"
       ],
       "out": "(def foo (bar\n           4 5 6\n           ; comment 1\n           7 8 9))\n           ; comment 2"
-    }
+    },
+    "id": 2145
   },
   {
     "text": "(foo (if some-condition\n         println) foo {:foo 1\n                          :bar 2})",
@@ -564,7 +594,8 @@
         "(my-fnfoo (if some-condition\n -----+++\n         println) my-funfoo {:foo 1\n                  ------+++\n                          :bar 2})"
       ],
       "out": "(foo (if some-condition\n       println) foo {:foo 1\n                     :bar 2})"
-    }
+    },
+    "id": 2150
   },
   {
     "text": "(foo [bar baz]\n       1 2 3\n       4 5 6)",
@@ -579,7 +610,8 @@
         "(foo [bar baz]\n       1 2 3\n       4 5 6)"
       ],
       "out": "(foo [bar baz]\n     1 2 3\n     4 5 6)"
-    }
+    },
+    "id": 2155
   },
   {
     "text": "(foo [bar baz\n         ]; <-- spaces\n       1 2 3\n       4 5 6)",
@@ -594,7 +626,8 @@
         "(foo [bar baz\n         ]; <-- spaces\n       1 2 3\n       4 5 6)"
       ],
       "out": "(foo [bar baz]\n         ; <-- spaces\n     1 2 3\n     4 5 6)"
-    }
+    },
+    "id": 2160
   },
   {
     "text": "(defn foo\n  \"hello, this is a docstring\"\n  [a b]\n  (let [sum (+ a b)\n        prod (* a b)]\n     {:sum sum\n      :prod prod}))",
@@ -631,7 +664,8 @@
         "(defn foo\n  \"hello, this is a docstring\"\n  [a b]\n  (let [sum (+ a b)\n        prod (* a b)]\n     {:sum sum\n      :prod prod}))"
       ],
       "out": "(defn foo\n  \"hello, this is a docstring\"\n  [a b]\n      ^ parenTrail\n  (let [sum (+ a b)\n                  ^ parenTrail\n        prod (* a b)]\n                   ^^ parenTrail\n     {:sum sum\n      :prod prod}))\n                ^^^ parenTrail"
-    }
+    },
+    "id": 2165
   },
   {
     "text": "  (foo\n  (bar\n    baz))",
@@ -655,7 +689,8 @@
         "  (foo\n++\n  (bar\n    baz))"
       ],
       "out": "  (foo\n    (bar\n      baz))"
-    }
+    },
+    "id": 2170
   },
   {
     "text": "  (foo\n    (bar\n    baz))",
@@ -685,7 +720,8 @@
         "  (foo\n++\n    (bar\n++\n    baz))"
       ],
       "out": "  (foo\n    (bar\n      baz))"
-    }
+    },
+    "id": 2175
   },
   {
     "text": "  (foo\n      (bar\n        baz))",
@@ -715,7 +751,8 @@
         "  (foo\n      (bar\n++\n        baz))\n++"
       ],
       "out": "  (foo\n      (bar\n        baz))"
-    }
+    },
+    "id": 2180
   },
   {
     "text": "  (foo\n  bar\n  baz)",
@@ -739,7 +776,8 @@
         "  (foo\n++\n  bar\n  baz)"
       ],
       "out": "  (foo\n    bar\n    baz)"
-    }
+    },
+    "id": 2185
   },
   {
     "text": "  (foo\n    bar\n  baz)",
@@ -769,7 +807,8 @@
         "  (foo\n++\n    bar\n++\n  baz)"
       ],
       "out": "  (foo\n    bar\n    baz)"
-    }
+    },
+    "id": 2190
   },
   {
     "text": "(foo\n    bar\n    baz)",
@@ -799,7 +838,8 @@
         "(foo\n    bar\n++\n    baz)\n++"
       ],
       "out": "(foo\n    bar\n    baz)"
-    }
+    },
+    "id": 2195
   },
   {
     "text": "(def x [1 2 3])\n(def y 2)\n",
@@ -827,7 +867,8 @@
         "(def x [1 2 3])\n(def y 2)\n|"
       ],
       "out": "(def x [1 2 3])\n(def y 2)\n^    > tabStops\n|"
-    }
+    },
+    "id": 2200
   },
   {
     "text": "(foo bar\n  (baz boo))\n",
@@ -860,7 +901,8 @@
         "(foo bar\n  (baz boo))\n|"
       ],
       "out": "(foo bar\n  (baz boo))\n^ ^    > tabStops\n|"
-    }
+    },
+    "id": 2205
   },
   {
     "text": "(let [a {:foo 1}\n      \n      bar [1 2 3]]\n  bar)",
@@ -898,7 +940,8 @@
         "(let [a {:foo 1}\n      |\n      bar [1 2 3]]\n  bar)"
       ],
       "out": "(let [a {:foo 1}\n^    ^  ^     > tabStops\n      |\n      bar [1 2 3]]\n  bar)"
-    }
+    },
+    "id": 2210
   },
   {
     "text": "(let [a {:foo 1}\n      bar (func 1 2 3)]\n  \n  bar)",
@@ -936,6 +979,7 @@
         "(let [a {:foo 1}\n      bar (func 1 2 3)]\n  |\n  bar)"
       ],
       "out": "(let [a {:foo 1}\n      bar (func 1 2 3)]\n^    ^    ^     > tabStops\n  |\n  bar)"
-    }
+    },
+    "id": 2215
   }
 ]

--- a/test/cases/paren-mode.md
+++ b/test/cases/paren-mode.md
@@ -4,7 +4,7 @@
 
 clamp left
 
-```in
+```in:2000
 (let [foo 1]
 foo)
 ```
@@ -16,7 +16,7 @@ foo)
 
 clamp right
 
-```in
+```in:2005
 (let [foo 1]
       foo)
 ```
@@ -26,7 +26,7 @@ clamp right
      foo)
 ```
 
-```in
+```in:2010
 (let [foo {:a 1}]
            foo)
 ```
@@ -38,7 +38,7 @@ clamp right
 
 sanity check to apply rules to multiple expressions
 
-```in
+```in:2015
 (let [foo 1]
       foo)
 
@@ -58,7 +58,7 @@ foo)
 
 keep relative indentation of child expressions:
 
-```in
+```in:2020
 (let [foo [1 2 3]]
       (-> foo
           (map inc)))
@@ -76,7 +76,7 @@ keep relative indentation of child expressions:
 Close-parens at start of line are moved to end of previous line.  Note that the
 spaces before the close-paren are not removed.
 
-```in
+```in:2025
 (let [foo 1
       ]; <-- spaces
   foo)
@@ -88,7 +88,7 @@ spaces before the close-paren are not removed.
   foo)
 ```
 
-```in
+```in:2030
 (let [foo 1
       bar 2
 
@@ -110,7 +110,7 @@ spaces before the close-paren are not removed.
 
 extra indent is fine (won't cause parinfer to restructure it)
 
-```in
+```in:2035
 (def x [1 2 3 4
          5 6 7 8])
 ```
@@ -122,7 +122,7 @@ extra indent is fine (won't cause parinfer to restructure it)
 
 doesn't try to align siblings.
 
-```in
+```in:2040
   (assoc x
 :foo 1
      :bar 2)
@@ -136,7 +136,7 @@ doesn't try to align siblings.
 
 ## Unclosed Parens
 
-```in
+```in:2045
 (foo
 ```
 
@@ -145,7 +145,7 @@ doesn't try to align siblings.
 ^ error: unclosed-paren
 ```
 
-```in
+```in:2050
 (defn foo
 [arg arg2
 bar
@@ -160,7 +160,7 @@ bar
 
 ## Unmatched close-parens
 
-```in
+```in:2055
 (foo})
 ```
 
@@ -169,7 +169,7 @@ bar
     ^ error: unmatched-close-paren
 ```
 
-```in
+```in:2060
 (foo
   })
 ```
@@ -180,7 +180,7 @@ bar
   ^ error: unmatched-close-paren
 ```
 
-```in
+```in:2065
 (defn foo
   [arg
   bar)
@@ -197,7 +197,7 @@ bar
 
 escape character in comment untouched:
 
-```in
+```in:2070
 ; hello \n world
 ```
 
@@ -207,7 +207,7 @@ escape character in comment untouched:
 
 escaped whitespace
 
-```in
+```in:2075
 (def foo \,)
 (def bar \ )
 ```
@@ -219,7 +219,7 @@ escaped whitespace
 
 Hanging backslash at end of line is invalid and causes processing to be abandoned.
 
-```in
+```in:2080
 (foo [a b]\
 c)
 ```
@@ -232,7 +232,7 @@ c)
 
 ## Unclosed Quotes
 
-```in
+```in:2085
 (def foo
   "hello
   bar)
@@ -249,7 +249,7 @@ c)
 
 odd number of quotes not allowed in a comment, so it remains unprocessed:
 
-```in
+```in:2090
 (def foo [a b]
   ; "my string
 ret)
@@ -264,7 +264,7 @@ ret)
 
 balanced quotes allowed across contiguous comments:
 
-```in
+```in:2095
 (def foo [a b]
   ; "my multiline
   ; docstring."
@@ -283,7 +283,7 @@ ret)
 A line ending inside a string will not have a definable Paren Trail.  This
 minimal test case will fail if the close-paren is treated as a Paren Trail.
 
-```in
+```in:2100
 ( )"
 "
 ```
@@ -298,7 +298,7 @@ minimal test case will fail if the close-paren is treated as a Paren Trail.
 Preserve spaces in paren trail for the cursor line.  This allows the user
 to insert things between close-parens more easily.
 
-```in
+```in:2105
 (foo |)
 ```
 
@@ -306,7 +306,7 @@ to insert things between close-parens more easily.
 (foo |)
 ```
 
-```in
+```in:2110
 (foo [1 2 3 |] )
 ```
 
@@ -316,7 +316,7 @@ to insert things between close-parens more easily.
 
 But get rid of spaces in paren trail if no cursor is present on the line:
 
-```in
+```in:2115
 (foo )
 ```
 
@@ -324,7 +324,7 @@ But get rid of spaces in paren trail if no cursor is present on the line:
 (foo)
 ```
 
-```in
+```in:2120
 (foo [1 2 3 ] )
 ```
 
@@ -336,7 +336,7 @@ But get rid of spaces in paren trail if no cursor is present on the line:
 
 Pressing enter before a close-paren.
 
-```in
+```in:2125
 (foo [a b
 |])
 ```
@@ -348,7 +348,7 @@ Pressing enter before a close-paren.
 
 Cursor pushed forward when a form is balanced and indented.
 
-```in
+```in:2130
 (foo [1 2 3
  4 5 6
  7 8 9])|
@@ -364,7 +364,7 @@ Cursor pushed forward when a form is balanced and indented.
 
 When backspacing, preserve the indentation of the child lines.
 
-```in
+```in:2135
 (let     [foo 1
      ----
            ; comment 1
@@ -381,7 +381,7 @@ When backspacing, preserve the indentation of the child lines.
        ; comment 2
 ```
 
-```in
+```in:2140
    (def foo
 ---
       ; comment 1
@@ -398,7 +398,7 @@ When backspacing, preserve the indentation of the child lines.
 
 When typing before an open-paren, preserve the indentation of the child lines.
 
-```in
+```in:2145
 (def foo (bar
     ++++
        4 5 6
@@ -417,7 +417,7 @@ When typing before an open-paren, preserve the indentation of the child lines.
 
 __Multiple changes__:
 
-```in
+```in:2150
 (my-fnfoo (if some-condition
  -----+++
          println) my-funfoo {:foo 1
@@ -445,7 +445,7 @@ which is likely an unintended side effect.
 This places a harder constraint on indentation in Paren Mode than Indent Mode,
 making the invariant no longer equivalent between them.
 
-```in
+```in:2155
 (foo [bar baz]
        1 2 3
        4 5 6)
@@ -457,7 +457,7 @@ making the invariant no longer equivalent between them.
      4 5 6)
 ```
 
-```in
+```in:2160
 (foo [bar baz
          ]; <-- spaces
        1 2 3
@@ -476,7 +476,7 @@ making the invariant no longer equivalent between them.
 We return non-empty Paren Trails so plugins can dim them with markers:
 
 
-```in
+```in:2165
 (defn foo
   "hello, this is a docstring"
   [a b]
@@ -504,7 +504,7 @@ We return non-empty Paren Trails so plugins can dim them with markers:
 
 Indent only the first line:
 
-```in
+```in:2170
   (foo
 ++
   (bar
@@ -519,7 +519,7 @@ Indent only the first line:
 
 Indent first two lines:
 
-```in
+```in:2175
   (foo
 ++
     (bar
@@ -535,7 +535,7 @@ Indent first two lines:
 
 Indent last two lines:
 
-```in
+```in:2180
   (foo
       (bar
 ++
@@ -552,7 +552,7 @@ Indent last two lines:
 
 Indent only the first line:
 
-```in
+```in:2185
   (foo
 ++
   bar
@@ -567,7 +567,7 @@ Indent only the first line:
 
 Indent first two lines:
 
-```in
+```in:2190
   (foo
 ++
     bar
@@ -583,7 +583,7 @@ Indent first two lines:
 
 Indent last two lines:
 
-```in
+```in:2195
 (foo
     bar
 ++
@@ -605,7 +605,7 @@ We can return the positions of the open-parens whose structure would be
 affected by the indentation of the current cursor line.  This allows editors to
 use them to create tab stops for smart indentation snapping.
 
-```in
+```in:2200
 (def x [1 2 3])
 (def y 2)
 |
@@ -621,7 +621,7 @@ use them to create tab stops for smart indentation snapping.
 The `>` means the position of the first arg after an open-paren, because some styles
 use it for alignment.
 
-```in
+```in:2205
 (foo bar
   (baz boo))
 |
@@ -634,7 +634,7 @@ use it for alignment.
 |
 ```
 
-```in
+```in:2210
 (let [a {:foo 1}
       |
       bar [1 2 3]]
@@ -649,7 +649,7 @@ use it for alignment.
   bar)
 ```
 
-```in
+```in:2215
 (let [a {:foo 1}
       bar (func 1 2 3)]
   |

--- a/test/cases/smart-mode.json
+++ b/test/cases/smart-mode.json
@@ -17,7 +17,8 @@
         "(let [a 1\n      |])"
       ],
       "out": "(let [a 1\n      |])"
-    }
+    },
+    "id": 3000
   },
   {
     "text": "(let [a 1\n      ]); <-- spaces",
@@ -32,7 +33,8 @@
         "(let [a 1\n      ]); <-- spaces"
       ],
       "out": "(let [a 1])\n      ; <-- spaces"
-    }
+    },
+    "id": 3005
   },
   {
     "text": "(let [a 1\n      ] (+ a 2))",
@@ -52,7 +54,8 @@
         "(let [a 1\n      |] (+ a 2))"
       ],
       "out": "(let [a 1\n      |] (+ a 2))"
-    }
+    },
+    "id": 3010
   },
   {
     "text": "(let [a 1\n      ] (+ a 2))",
@@ -67,7 +70,8 @@
         "(let [a 1\n      ] (+ a 2))"
       ],
       "out": "(let [a 1]\n     (+ a 2))"
-    }
+    },
+    "id": 3015
   },
   {
     "text": "(let [a 1\n  ] (+ a 2))",
@@ -87,7 +91,8 @@
         "(let [a 1\n  |] (+ a 2))"
       ],
       "out": "(let [a 1\n      |] (+ a 2))"
-    }
+    },
+    "id": 3020
   },
   {
     "text": "(let [a 1\n      ])",
@@ -107,7 +112,8 @@
         "(let [a 1\n      ]|)"
       ],
       "out": "(let [a 1]\n     |)"
-    }
+    },
+    "id": 3025
   },
   {
     "text": ")",
@@ -135,7 +141,8 @@
         "(|)\n-"
       ],
       "out": "|"
-    }
+    },
+    "id": 3030
   },
   {
     "text": "(foo\n  ))",
@@ -163,7 +170,8 @@
         "(foo\n  (bar|))\n  ----"
       ],
       "out": "(foo\n  |)"
-    }
+    },
+    "id": 3035
   },
   {
     "text": "(foo\n  })",
@@ -183,7 +191,8 @@
         "(foo\n  }|)"
       ],
       "out": "(foo\n  |)"
-    }
+    },
+    "id": 3040
   },
   {
     "text": "(foo\n  ) foo} bar",
@@ -208,7 +217,8 @@
         "(foo\n  ) foo} bar|"
       ],
       "out": "(foo\n  ) foo} bar|\n       ^ error: unmatched-close-paren"
-    }
+    },
+    "id": 3045
   },
   {
     "text": "(foo\n  ) (bar",
@@ -233,7 +243,8 @@
         "(foo\n  ) (bar|"
       ],
       "out": "(foo\n  ) (bar|\n    ^ error: unclosed-paren"
-    }
+    },
+    "id": 3050
   },
   {
     "text": "(foo (bar)\n      baz)",
@@ -257,7 +268,8 @@
         "(foo (bar)\n      baz)\n     +"
       ],
       "out": "(foo (bar\n      baz))"
-    }
+    },
+    "id": 3055
   },
   {
     "text": "(foo\n{:a 1\n   :b 2})",
@@ -281,7 +293,8 @@
         "(foo\n  {:a 1\n--\n   :b 2})"
       ],
       "out": "(foo)\n{:a 1\n :b 2}"
-    }
+    },
+    "id": 3060
   },
   {
     "text": "(foo)\n  {:a 1\n :b 2}",
@@ -305,7 +318,8 @@
         "(foo)\n  {:a 1\n++\n :b 2}"
       ],
       "out": "(foo\n  {:a 1\n   :b 2})"
-    }
+    },
+    "id": 3065
   },
   {
     "text": "(foo\n  {:a 1\n:b 2})",
@@ -329,7 +343,8 @@
         "(foo\n  {:a 1\n   :b 2})\n---"
       ],
       "out": "(foo\n  {:a 1})\n:b 2"
-    }
+    },
+    "id": 3070
   },
   {
     "text": "(defn foo\n[a b]\n  bar)",
@@ -353,7 +368,8 @@
         "(defn foo\n  [a b]\n--\n  bar)"
       ],
       "out": "(defn foo)\n[a b\n  bar]"
-    }
+    },
+    "id": 3075
   },
   {
     "text": "(defn foo\n    [a b]\n    bar)",
@@ -377,7 +393,8 @@
         "  (defn foo\n--\n    [a b]\n    bar)"
       ],
       "out": "(defn foo\n  [a b]\n  bar)"
-    }
+    },
+    "id": 3080
   },
   {
     "text": "(defn foo\n    [a b]\n    ; comment 1\n    bar)\n    ; comment 2",
@@ -401,7 +418,8 @@
         "  (defn foo\n--\n    [a b]\n    ; comment 1\n    bar)\n    ; comment 2"
       ],
       "out": "(defn foo\n  [a b]\n  ; comment 1\n  bar)\n  ; comment 2"
-    }
+    },
+    "id": 3085
   },
   {
     "text": "(defn foo\n[a b\n   c d]\n  bar\n  baz)",
@@ -429,7 +447,8 @@
         "(defn foo\n  |[a b\n--\n   c d]\n  bar\n  baz)"
       ],
       "out": "(defn foo)\n|[a b\n c d]\n  bar\n  baz"
-    }
+    },
+    "id": 3090
   },
   {
     "text": "(defn foo)\n[a b\n c d]\n  bar\n  baz",
@@ -449,7 +468,8 @@
         "(defn foo)\n|[a b\n c d]\n  bar\n  baz"
       ],
       "out": "(defn foo)\n|[a b\n c d]\n  bar\n  baz"
-    }
+    },
+    "id": 3095
   },
   {
     "text": "(foo (if some-condition\n         println) foo {:foo 1\n                          :bar 2})",
@@ -479,7 +499,8 @@
         "(my-fnfoo (if some-condition\n -----+++\n         println) my-funfoo {:foo 1\n                  ------+++\n                          :bar 2})"
       ],
       "out": "(foo (if some-condition\n       println) foo {:foo 1\n                     :bar 2})"
-    }
+    },
+    "id": 3100
   },
   {
     "text": "((((1\n        2\n        3)))\n    4)",
@@ -507,7 +528,8 @@
         "(foo |(((1\n ----\n        2\n        3)))\n    4)"
       ],
       "out": "(|(((1\n    2\n    3)))\n    4)"
-    }
+    },
+    "id": 3105
   },
   {
     "text": "((((1\n    2\n    3)))\n    4)",
@@ -525,7 +547,8 @@
         "((((1\n ^ prevCursor\n    2\n    3)))\n    4)"
       ],
       "out": "((((1\n    2\n    3)))\n 4)"
-    }
+    },
+    "id": 3110
   },
   {
     "text": "((((1\n    2\n    3)))\n    4)",
@@ -547,7 +570,8 @@
         "((|((1\n ^ prevCursor\n    2\n    3)))\n    4)"
       ],
       "out": "((|((1\n    2\n    3)))\n 4)"
-    }
+    },
+    "id": 3115
   },
   {
     "text": "  (foo\n  (bar\n    baz))",
@@ -571,7 +595,8 @@
         "  (foo\n++\n  (bar\n    baz))"
       ],
       "out": "  (foo\n    (bar\n      baz))"
-    }
+    },
+    "id": 3120
   },
   {
     "text": "  (foo\n    (bar\n    baz))",
@@ -601,7 +626,8 @@
         "  (foo\n++\n    (bar\n++\n    baz))"
       ],
       "out": "  (foo\n    (bar\n      baz))"
-    }
+    },
+    "id": 3125
   },
   {
     "text": "  (foo\n      (bar\n        baz))",
@@ -631,7 +657,8 @@
         "  (foo\n      (bar\n++\n        baz))\n++"
       ],
       "out": "  (foo\n      (bar\n        baz))"
-    }
+    },
+    "id": 3130
   },
   {
     "text": "  (foo\n  bar\n  baz)",
@@ -655,7 +682,8 @@
         "  (foo\n++\n  bar\n  baz)"
       ],
       "out": "  (foo\n    bar\n    baz)"
-    }
+    },
+    "id": 3135
   },
   {
     "text": "  (foo\n    bar\n  baz)",
@@ -685,7 +713,8 @@
         "  (foo\n++\n    bar\n++\n  baz)"
       ],
       "out": "  (foo\n    bar\n    baz)"
-    }
+    },
+    "id": 3140
   },
   {
     "text": "(foo\n    bar\n    baz)",
@@ -715,7 +744,8 @@
         "(foo\n    bar\n++\n    baz)\n++"
       ],
       "out": "(foo\n    bar\n    baz)"
-    }
+    },
+    "id": 3145
   },
   {
     "text": "((reduce-kv (fn [m k v]\n            {}\n            {})))",
@@ -758,7 +788,8 @@
         "((reduce-kv (fn [m k v]\n            {}\n            {})))\n                +"
       ],
       "out": "((reduce-kv (fn [m k v])\n            {}\n            {}))"
-    }
+    },
+    "id": 3150
   },
   {
     "text": "(let [a 1]\n  (\n    (foo)))",
@@ -795,7 +826,8 @@
         "(let [a 1]\n  (\n    (foo)))\n         +"
       ],
       "out": "(let [a 1]\n  (\n    (foo)))"
-    }
+    },
+    "id": 3155
   },
   {
     "text": "(let [a 1]\n  (let [a 1]\n    (foo))\n  (foo))",
@@ -827,7 +859,8 @@
         "(let [a 1]\n  (let [a 1]\n    (foo))\n  ++\n  (foo))"
       ],
       "out": "(let [a 1]\n  (let [a 1]\n    (foo))\n  (foo))"
-    }
+    },
+    "id": 3160
   },
   {
     "text": "{:a {:b (Integer/valueOf (-> \"\"\n                             (.length)))}}",
@@ -864,6 +897,7 @@
         "{:a {:b              (Integer/valueOf (-> \"\"\n        -------------\n                                                          (.length)))}}\n                             -----------------------------"
       ],
       "out": "{:a {:b (Integer/valueOf (-> \"\"\n                             (.length)))}}"
-    }
+    },
+    "id": 3165
   }
 ]

--- a/test/cases/smart-mode.md
+++ b/test/cases/smart-mode.md
@@ -8,7 +8,7 @@ so we exit to paren mode when they are detected.
 For example, it is convenient to keep trailing parens in front of the cursor
 after pressing enter or after deleting everything behind them:
 
-```in
+```in:3000
 (let [a 1
       |])
 ```
@@ -20,7 +20,7 @@ after pressing enter or after deleting everything behind them:
 
 Moving the cursor away:
 
-```in
+```in:3005
 (let [a 1
       ]); <-- spaces
 ```
@@ -33,7 +33,7 @@ Moving the cursor away:
 But we also need safety from inadvertent AST breakage.  For example,
 Indent Mode should allow this intermediate state:
 
-```in
+```in:3010
 (let [a 1
       |] (+ a 2))
 ```
@@ -47,7 +47,7 @@ Moving the cursor away will cause Indent Mode to still detect the leading
 close-paren, exit to Paren Mode, then fix the spacing to prevent inadvertent
 breakage.
 
-```in
+```in:3015
 (let [a 1
       ] (+ a 2))
 ```
@@ -61,7 +61,7 @@ To prevent weird things, indentation needs to be locked to respect
 the leading close-paren.  Exiting to Paren Mode allows this and prevents further
 AST breakage.
 
-```in
+```in:3020
 (let [a 1
   |] (+ a 2))
 ```
@@ -74,7 +74,7 @@ AST breakage.
 Moving cursor to the right progressively moves leading close-parens behind it
 to their normal positions:
 
-```in
+```in:3025
 (let [a 1
       ]|)
 ```
@@ -89,7 +89,7 @@ When in Paren Mode we must abide by its rules to stay balanced.
 As a courtesy, unmatched close-parens in a paren trail at the beginning of a
 line are auto-removed (only when paren mode is triggered from smart mode).
 
-```in
+```in:3030
 (|)
 -
 ```
@@ -98,7 +98,7 @@ line are auto-removed (only when paren mode is triggered from smart mode).
 |
 ```
 
-```in
+```in:3035
 (foo
   (bar|))
   ----
@@ -109,7 +109,7 @@ line are auto-removed (only when paren mode is triggered from smart mode).
   |)
 ```
 
-```in
+```in:3040
 (foo
   }|)
 ```
@@ -121,7 +121,7 @@ line are auto-removed (only when paren mode is triggered from smart mode).
 
 Likewise:
 
-```in
+```in:3045
 (foo
   ) foo} bar|
 ```
@@ -132,7 +132,7 @@ Likewise:
        ^ error: unmatched-close-paren
 ```
 
-```in
+```in:3050
 (foo
   ) (bar|
 ```
@@ -148,7 +148,7 @@ Likewise:
 
 Indent a single-line expression to enter a sibling:
 
-```in
+```in:3055
 (foo (bar)
       baz)
      +
@@ -161,7 +161,7 @@ Indent a single-line expression to enter a sibling:
 
 Dedent multi-line expression to leave its parent:
 
-```in
+```in:3060
 (foo
   {:a 1
 --
@@ -176,7 +176,7 @@ Dedent multi-line expression to leave its parent:
 
 Indent multi-line expression to enter new parent:
 
-```in
+```in:3065
 (foo)
   {:a 1
 ++
@@ -191,7 +191,7 @@ Indent multi-line expression to enter new parent:
 
 Dedenting an inner line makes it leave parent:
 
-```in
+```in:3070
 (foo
   {:a 1
    :b 2})
@@ -206,7 +206,7 @@ Dedenting an inner line makes it leave parent:
 
 Dedenting a collection will adopt a former sibling line below it:
 
-```in
+```in:3075
 (defn foo
   [a b]
 --
@@ -221,7 +221,7 @@ Dedenting a collection will adopt a former sibling line below it:
 
 But dedenting a top-level form should not cause a child to adopt a sibling:
 
-```in
+```in:3080
   (defn foo
 --
     [a b]
@@ -236,7 +236,7 @@ But dedenting a top-level form should not cause a child to adopt a sibling:
 
 Indented comments move with expressions:
 
-```in
+```in:3085
   (defn foo
 --
     [a b]
@@ -258,7 +258,7 @@ Indented comments move with expressions:
 To prevent undesirable sibling adoption when dedenting, we temporarily keep
 a close-paren from moving when the cursor is to the left of its open-paren.
 
-```in
+```in:3090
 (defn foo
   |[a b
 --
@@ -275,7 +275,7 @@ a close-paren from moving when the cursor is to the left of its open-paren.
   baz
 ```
 
-```in
+```in:3095
 (defn foo)
 |[a b
  c d]
@@ -293,7 +293,7 @@ a close-paren from moving when the cursor is to the left of its open-paren.
 
 ## Multiple Changes
 
-```in
+```in:3100
 (my-fnfoo (if some-condition
  -----+++
          println) my-funfoo {:foo 1
@@ -312,7 +312,7 @@ a close-paren from moving when the cursor is to the left of its open-paren.
 Suppose we deleted `foo` in the example below.  We expect `4` to not be adopted
 by any collection inside `(((1 2 3)))`.
 
-```in
+```in:3105
 (foo |(((1
  ----
         2
@@ -330,7 +330,7 @@ by any collection inside `(((1 2 3)))`.
 When cursor is removed, the precarious parens are resolved by preserving structure
 and correcting indentation.
 
-```in
+```in:3110
 ((((1
  ^ prevCursor
     2
@@ -345,7 +345,7 @@ and correcting indentation.
  4)
 ```
 
-```in
+```in:3115
 ((|((1
  ^ prevCursor
     2
@@ -364,7 +364,7 @@ and correcting indentation.
 
 Indent only the first line:
 
-```in
+```in:3120
   (foo
 ++
   (bar
@@ -379,7 +379,7 @@ Indent only the first line:
 
 Indent first two lines:
 
-```in
+```in:3125
   (foo
 ++
     (bar
@@ -395,7 +395,7 @@ Indent first two lines:
 
 Indent last two lines:
 
-```in
+```in:3130
   (foo
       (bar
 ++
@@ -412,7 +412,7 @@ Indent last two lines:
 
 Indent only the first line:
 
-```in
+```in:3135
   (foo
 ++
   bar
@@ -427,7 +427,7 @@ Indent only the first line:
 
 Indent first two lines:
 
-```in
+```in:3140
   (foo
 ++
     bar
@@ -443,7 +443,7 @@ Indent first two lines:
 
 Indent last two lines:
 
-```in
+```in:3145
 (foo
     bar
 ++
@@ -461,7 +461,7 @@ Indent last two lines:
 
 [Issue #173](https://github.com/shaunlebron/parinfer/issues/173)
 
-```in
+```in:3150
 ((reduce-kv (fn [m k v]
 +
             {}
@@ -485,7 +485,7 @@ Indent last two lines:
 
 [Issue #176](https://github.com/shaunlebron/parinfer/issues/176)
 
-```in
+```in:3155
 (let [a 1]
   (
   +
@@ -508,7 +508,7 @@ Indent last two lines:
 
 [Issue #177](https://github.com/shaunlebron/parinfer/issues/177)
 
-```in
+```in:3160
 (let [a 1]
 
   (foo))
@@ -540,7 +540,7 @@ Indent last two lines:
 
 [Issue #179](https://github.com/shaunlebron/parinfer/issues/179)
 
-```in
+```in:3165
 {:a                 {:b              (Integer/valueOf (-> ""
     ----------------
                                                           (.length)))}}


### PR DESCRIPTION
Part of Issue #13 - give all test cases a stable identifier

- [x] indent mode cases
- [x] paren mode cases
- [x] smart mode cases
- [x] allow testing cases by specific id

```sh
npx mocha --id:1005 --id:2055
```